### PR TITLE
Fix panic if all players but one fold preflop

### DIFF
--- a/table/table.go
+++ b/table/table.go
@@ -289,20 +289,24 @@ func (t *Table) payout() {
 		})
 		// select winners who split pot if more than one
 		winners := []*Player{}
-		h1 := hands[pot.contesting[0]]
-		for _, seat := range pot.contesting {
-			h2 := hands[seat]
-			if h1.CompareTo(h2) != 0 {
-				break
+		if len(pot.contesting) == 1 {
+			winners = []*Player{pot.contesting[0]}
+		} else {
+			h1 := hands[pot.contesting[0]]
+			for _, seat := range pot.contesting {
+				h2 := hands[seat]
+				if h1.CompareTo(h2) != 0 {
+					break
+				}
+				winners = append(winners, seat)
 			}
-			winners = append(winners, seat)
+			// sort closest to the button for spare chips in split pot
+			sort.Slice(winners, func(i, j int) bool {
+				iDist := t.distanceFromButton(winners[i])
+				jDist := t.distanceFromButton(winners[j])
+				return iDist < jDist
+			})
 		}
-		// sort closest to the button for spare chips in split pot
-		sort.Slice(winners, func(i, j int) bool {
-			iDist := t.distanceFromButton(winners[i])
-			jDist := t.distanceFromButton(winners[j])
-			return iDist < jDist
-		})
 		// payout chips
 		for i, seat := range winners {
 			seat.Chips += pot.chips / len(winners)

--- a/table/table_test.go
+++ b/table/table_test.go
@@ -50,6 +50,18 @@ var (
 			},
 			description: "full hand 1",
 		},
+		{
+			start: threePerson100Buyin(),
+			actions: []table.Action{
+				{table.Raise, 5},
+				{Type: table.Fold},
+				{Type: table.Fold},
+			},
+			condition: func(s table.State) bool {
+				return s.Seats[0].Chips == 97 && s.Seats[1].Chips == 101 && s.Seats[2].Chips == 99 && s.Round == table.PreFlop
+			},
+			description: "preflop folds",
+		},
 	}
 )
 


### PR DESCRIPTION
Hi there,

Thanks for publishing this library, I was impressed by how comprehensive it is!

I found a bug where, if all the players fold pre-flop but one, it panics as the the players' hands are not big enough without any table cards for comparisons in the payout. I solved this by checking if the number of players contesting the pot is greater than one, and, if not, simply awarding the pot to the only contestant. Please see the test case I added as well.

Hope this is helpful, thanks again!

- alcamerone